### PR TITLE
Typo fix + CNS student group

### DIFF
--- a/content/pages/groups.md
+++ b/content/pages/groups.md
@@ -6,5 +6,6 @@ sortorder: 2
 - The [International Collegiate Programming Contest](https://www.cs.virginia.edu/~asb/icpc/) team
     - And the [High School Programming Contest](http://acm.cs.virginia.edu/hspc.php) group
 - [Code for Good](http://codeforgooduva.weebly.com/)
+- [Computer Network and Security Club](https://cnsatuva.github.io)
 - [hack.uva](http://hackuva.io)
 - [Student Game Developers](http://sgd.cs.virginia.edu/)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -31,7 +31,7 @@ SOCIAL = (('Facebook (by students)', 'https://www.facebook.com/groups/2168565850
           ('Github','https://github.com/uva-cs'),
           ('Twitter feed: @CS_UVa','https://twitter.com/cs_uva'),
           ('LinkedIn account','https://www.linkedin.com/groups/3998950'),
-          ('Instragram','https://www.instagram.com/uva_cs/'),)
+          ('Instagram','https://www.instagram.com/uva_cs/'),)
 
 DEFAULT_PAGINATION = 10
 


### PR DESCRIPTION
Added the Computer and Network Security club to the student club listings, and fixed a minor typo. 